### PR TITLE
Fixed import of models in company serializers

### DIFF
--- a/corexen/companies/serializers.py
+++ b/corexen/companies/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from corexen.companies import Company, Headquarter
+from corexen.companies.models import Company, Headquarter
 
 
 class CompanyModelSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
¿Cómo se les pasó hacer eso?
Se supone que no debió funcionar al usar los factories