### PR TITLE
Add support for custom permissions

### DIFF
--- a/corexen/users/permissions.py
+++ b/corexen/users/permissions.py
@@ -10,6 +10,7 @@ class UserHeadquarterPermissions(DjangoModelPermissions):
     def __init__(self):
         """"""
         self.headquarter = None
+        self.custom_action = ''
 
     perms_map = {
         'GET': ['%(app_label)s.view_%(model_name)s.%(headquarter)s'],
@@ -26,6 +27,7 @@ class UserHeadquarterPermissions(DjangoModelPermissions):
         kwargs = {
             'app_label': model_cls._meta.app_label,
             'model_name': model_cls._meta.model_name,
+            'action_name: self.custom_action,
             'headquarter': headquarter
         }
 


### PR DESCRIPTION
By default no perms_map reads the action_name key, it must be overwritten in child classes to give it behavior