### PR TITLE
Add is verified email and is verified phone to user model

### DIFF
--- a/corexen/users/models.py
+++ b/corexen/users/models.py
@@ -1,15 +1,10 @@
-import unicodedata
 from distutils.version import LooseVersion
 from uuid import uuid4
 
 from django.contrib import auth
 from django.contrib.auth.models import (
-    UserManager,
-    _user_has_module_perms,
+    AbstractBaseUser, Group, Permission, UserManager, _user_has_module_perms,
     _user_has_perm,
-    Permission,
-    Group,
-    AbstractBaseUser
 )
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.contrib.postgres.fields import CICharField, CIEmailField
@@ -292,6 +287,28 @@ class User(AbstractUser,
     class Meta:
         """Meta options."""
         ordering = ('first_name', 'last_name')
+
+    @property
+    def is_verified_email(self):
+        """Returns true if user has verified email."""
+        if self.email and not (
+            self.non_verified_email
+            and self.email != self.non_verified_email
+        ):
+            return True
+
+        return False
+
+    @property
+    def is_verified_phone_number(self):
+        """Returns true if user has verified phone."""
+        if self.phone_number and not (
+            self.non_verified_phone_number
+            and self.phone_number != self.non_verified_phone_number
+        ):
+            return True
+
+        return False
 
 
 class UserPermission(CitixenModel):

--- a/tests/test_users/test_models.py
+++ b/tests/test_users/test_models.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.utils import timezone
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import Permission
 from faker import Faker
@@ -107,3 +108,241 @@ class UsernameValidationTestCase(CitixenTestCase):
         user = User.objects.create_user(username='MYUSERNAMEINUPPERCASE')
         user.refresh_from_db()
         self.assertEqual(user.username, 'myusernameinuppercase')
+
+
+class VerificationEmailTestCase(CitixenTestCase):
+
+    def test_no_verified_two_diffs_emails_and_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'email': fake.email(),
+            'non_verified_email': fake.email(),
+            'email_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_email
+
+        # Assert
+        self.assertFalse(is_verified)
+
+    def test_same_emails_and_verification_date(self):
+        # Arrange
+        email = fake.email()
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'email': email,
+            'non_verified_email': email,
+            'email_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_email
+
+        # Assert
+        self.assertTrue(is_verified)
+
+    def test_email_without_verification_date(self):
+        # Arrange
+        email = fake.email()
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'email': email,
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_email
+
+        # Assert
+        self.assertTrue(is_verified)
+
+    def test_non_verified_email_without_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'non_verified_email': fake.email(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_email
+
+        # Assert
+        self.assertFalse(is_verified)
+
+    def test_non_verified_email_with_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'non_verified_email': fake.email(),
+            'email_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_email
+
+        # Assert
+        self.assertFalse(is_verified)
+
+    def test_email_with_verification_date(self):
+        # Arrange
+        email = fake.email()
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'email': email,
+            'email_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_email
+
+        # Assert
+        self.assertTrue(is_verified)
+
+    def test_two_diffs_emails_without_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'email': fake.email(),
+            'non_verified_email': fake.email(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_email
+
+        # Assert
+        self.assertFalse(is_verified)
+
+
+class VerificationPhoneNumberTestCase(CitixenTestCase):
+
+    def test_no_verified_two_diffs_phones_with_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'phone_number': fake.numerify('+5731########'),
+            'non_verified_phone_number': fake.numerify('+5731########'),
+            'phone_number_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_phone_number
+
+        # Assert
+        self.assertFalse(is_verified)
+
+    def test_non_verified_phone_without_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'non_verified_phone_number': fake.numerify('+5731########'),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_phone_number
+
+        # Assert
+        self.assertFalse(is_verified)
+
+    def test_non_verified_phone_with_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'non_verified_phone_number': fake.numerify('+5731########'),
+            'email_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_phone_number
+
+        # Assert
+        self.assertFalse(is_verified)
+
+    def test_two_diffs_phones_without_verification_date(self):
+        # Arrange
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'phone_number': fake.numerify('+5731########'),
+            'non_verified_phone_number': fake.numerify('+5731########'),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_phone_number
+
+        # Assert
+        self.assertFalse(is_verified)
+
+    def test_same_phones_with_verification_date(self):
+        # Arrange
+        phone_number = fake.numerify('+5731########')
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'phone_number': phone_number,
+            'non_verified_phone_number': phone_number,
+            'email_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_phone_number
+
+        # Assert
+        self.assertTrue(is_verified)
+
+    def test_phone_without_verification_date(self):
+        # Arrange
+        phone_number = fake.numerify('+5731########')
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'phone_number': phone_number,
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_phone_number
+
+        # Assert
+        self.assertTrue(is_verified)
+
+    def test_phone_with_verification_date(self):
+        # Arrange
+        phone_number = fake.numerify('+5731########')
+        user_data = {
+            'username': fake.user_name(),
+            'password': fake.password(),
+            'phone_number': phone_number,
+            'email_verified_at': timezone.now(),
+        }
+        user = User.objects.create(**user_data)
+
+        # Act
+        is_verified = user.is_verified_phone_number
+
+        # Assert
+        self.assertTrue(is_verified)
+
+


### PR DESCRIPTION
Add `is_verified_email` and `is_verified_phone_number` to user model:

```python
@property
def is_verified_email(self):
    """Returns true if user has verified email."""
    if self.email and not (
        self.non_verified_email
        and self.email != self.non_verified_email
    ):
        return True

    return False

@property
def is_verified_phone_number(self):
    """Returns true if user has verified phone."""
    if self.phone_number and not (
        self.non_verified_phone_number
        and self.phone_number != self.non_verified_phone_number
    ):
        return True

    return False
```
Now, you you can verify if user has verified his email or phone number, by example:

```python
user = User.objects.create_user(
    username='user', 
    phone_number='+573109387493',
    phone_number_verified_at=timezone.now(),
    email='user@mail.com',
    email_verified_at=timezone.now()
)
user.is_verified_email  # True
user.is_verified_phone_number  # True
```